### PR TITLE
implement write instrument

### DIFF
--- a/development/config/attr.yaml
+++ b/development/config/attr.yaml
@@ -11,7 +11,7 @@
 - ino: 2
   name: file1
   file-type: 1
-  size: 24
+  size: 29
   uid: 1000
   gid: 1000
   perm: 0o644
@@ -31,3 +31,17 @@
   uid: 1000
   gid: 1000
   perm: 0o644
+- ino: 2
+  name: file1
+  file-type: 1
+  size: 34
+  uid: 1000
+  gid: 1000
+  perm: 0o644
+- ino: 2
+  name: file1
+  file-type: 0
+  size: 38
+  uid: 1000
+  gid: 1000
+  perm: 644

--- a/development/config/data.yaml
+++ b/development/config/data.yaml
@@ -3,3 +3,15 @@
 
 - ino: 4
   data: ""
+- ino: 2
+  data: "this is content of file1hoge
+"
+- ino: 2
+  data: "this is content of file1hoge fuga
+"
+- ino: 2
+  data: "this is content of file1hoge fuck
+"
+- ino: 2
+  data: "this is content of file1hoge fuck wow
+"

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -33,7 +33,8 @@ pub enum Error {
     InvalidGID,
     InvalidPERM,
     InvalidData,
-    InvalidEntry
+    InvalidEntry,
+    InternalError
 }
 
 impl fmt::Display for Error {
@@ -48,6 +49,7 @@ impl fmt::Display for Error {
             Self::InvalidPERM => write!(f, "There is no permission or permission is invalid"),
             Self::InvalidData => write!(f, "There is no data or data is invalid"),
             Self::InvalidEntry => write!(f, "There is no entry or entry is invalid"),
+            Self::InternalError => write!(f, "Internal Error")
         } 
     }
 }
@@ -75,5 +77,29 @@ impl FileStruct {
             Some(data) => return Some(data),
             None => return None
         }
+    }
+
+    pub fn update_data(&mut self, ino: u64, data: data::Data) -> Result<(), Error> {
+        self.data.insert(ino, data);
+        return Ok(());
+    }
+
+    pub fn update_size(&mut self, ino: u64, size: u64) -> Result<(), Error> {
+        let attr = match self.attr.get(&ino) {
+            Some(attr) => attr,
+            None => return Err(Error::InternalError)
+        };
+
+        let new_attr = attr::new(
+            ino,
+            size,
+            attr.name().to_string(),
+            attr.kind(),
+            attr.perm(),
+            attr.uid(),
+            attr.gid()
+        );
+        self.attr.insert(ino, new_attr);
+        return Ok(());
     }
 }

--- a/src/entity/attr.rs
+++ b/src/entity/attr.rs
@@ -45,30 +45,34 @@ pub fn new(
 
 impl Attr {
     pub fn ino(&self) -> u64 {
-        return self.ino;
+        self.ino
     }
 
     pub fn size(&self) -> u64 {
-        return self.size;
+        self.size
     }
 
     pub fn name(&self) -> &str {
-        return &self.name;
+        &self.name
     }
 
     pub fn file_type(&self) -> FileType {
-        return self.kind;
+        self.kind
     }
 
     pub fn perm(&self) -> u16 {
-        return self.perm;
+        self.perm
     }
 
     pub fn uid(&self) -> u32 {
-        return self.uid;
+        self.uid
     }
 
     pub fn gid(&self) -> u32 {
-        return self.gid;
+        self.gid
+    }
+
+    pub fn kind(&self) -> FileType {
+        self.kind
     }
 }

--- a/src/externalinterface/fuse.rs
+++ b/src/externalinterface/fuse.rs
@@ -6,7 +6,8 @@ use fuse::{
     ReplyAttr,
     ReplyData,
     ReplyDirectory,
-    Request
+    Request,
+    ReplyWrite
 };
 use std::ffi::OsStr;
 use time;
@@ -91,5 +92,13 @@ impl<C: controller::Controller> Filesystem for FuseStruct<C> {
 
         reply.data(data);
     } 
+
+    fn write(&mut self, _req: &Request<'_>, ino: u64, _fh: u64, offset: i64, data: &[u8], flags: u32, reply: ReplyWrite) {
+        let size = match self.controller.write(ino, offset as u64, data) {
+            Ok(data) => data,
+            Err(_) => return reply.error(libc::ENOENT)
+        };
+        reply.written(size)
+    }
 }
 

--- a/src/interfaceadapter/file_repository.rs
+++ b/src/interfaceadapter/file_repository.rs
@@ -1,6 +1,6 @@
 use std::path;
 use crate::usecase::repository::File;
-use crate::entity;
+use crate::entity::{self, attr};
 use crate::interfaceadapter::{worker};
 use anyhow::Result;
 
@@ -18,11 +18,23 @@ pub fn new<F>(file_worker: F) -> impl File
 
 impl<F: worker::File> File for FileRepositoryStruct<F> {
     fn init(&mut self, path: &path::Path) -> Result<entity::FileStruct> {
-        let files = match self.file_worker.init(path) {
-            Ok(files) => files,
-            Err(e) => return Err(e)
-        };
+        match self.file_worker.init(path) {
+            Ok(files) => Ok(files),
+            Err(e) => Err(e)
+        }
+    }
 
-        return Ok(files); 
+    fn write_data(&self, ino: u64, data: &str) -> Result<()> {
+        match self.file_worker.write_data(ino, data) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into())
+        }
+    }
+
+    fn update_attr(&self, attr: &attr::Attr) -> Result<()> {
+        match self.file_worker.update_attr(attr) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into())
+        }
     }
 }

--- a/src/interfaceadapter/worker.rs
+++ b/src/interfaceadapter/worker.rs
@@ -4,4 +4,6 @@ use anyhow::Result;
 
 pub trait File {
     fn init(&mut self, path: &path::Path) -> Result<entity::FileStruct>;
+    fn write_data(&self, ino: u64, data: &str) -> Result<()>;
+    fn update_attr(&self, attr: &attr::Attr) -> Result<()>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,6 @@ fn main() {
         Err(()) => panic!("Initialize error")
     };
 
-    // fs.init();
-    // fs.lookup();
-    // fs.getattr();
-
 	println!("mounted hfs");
     fuse::mount(fs, &mountpoint, &[]).expect("failed mount");
 }

--- a/src/usecase.rs
+++ b/src/usecase.rs
@@ -3,7 +3,7 @@ pub mod repository;
 use std::path;
 use std::ffi::OsStr;
 use anyhow::Result;
-use crate::entity::{self, attr};
+use crate::entity::{self, attr, data};
 
 #[derive(Debug)]
 struct UsecaseStruct<F: repository::File> {
@@ -17,6 +17,7 @@ pub trait Usecase {
     fn attr_from_ino(&self, ino: u64) -> Option<&attr::Attr>;
     fn readdir(&self, ino: u64) -> Option<Vec<(u64, &str, attr::FileType)>>;
     fn read(&self, ino: u64, offset: i64, size: u64) -> Option<&str>;
+    fn write(&mut self, ino: u64, offset: u64, data: &str) -> Result<u64>;
 }
 
 pub fn new<F>(file_repository: F) -> impl Usecase 
@@ -115,7 +116,95 @@ impl<F: repository::File> Usecase for UsecaseStruct<F> {
         let text_data = data.data();
         let end = offset as u64 + size;
 
+        // offsetを考慮して返却する必要がある
         return Some(text_data);
 //        return Some(&text_data[(offset as usize)..(end as usize)]);
+    }
+
+    fn write(&mut self, ino: u64, offset: u64, data: &str) -> Result<u64> {
+        let entity = match &mut self.entity {
+            Some(entity) => entity,
+            None => return Err(entity::Error::InternalError.into()) 
+        }; 
+        let old_data = match entity.data(&ino) {
+            Some(data) => data,
+            None => return Err(entity::Error::InternalError.into())
+        };
+        let old_str = old_data.data();
+        let new_text_data = match merge_str(offset, data, old_str) {
+            Ok(new_text_data) => new_text_data,
+            Err(e) => return Err(e.into())
+        };
+        let len: u64 = new_text_data.len() as u64;
+
+        self.file_repository.write_data(ino, new_text_data.as_str());
+        
+        let attr = match entity.attr(&ino) {
+            Some(attr) => attr,
+            None => return Err(entity::Error::InternalError.into())
+        };
+        let new_attr = attr::new(
+            ino,
+            len,
+            attr.name().to_string(),
+            attr.kind(),
+            attr.perm(),
+            attr.uid(),
+            attr.gid()
+        );
+        self.file_repository.update_attr(&new_attr);
+
+        let data = data::new(ino, new_text_data);
+
+        entity.update_data(ino, data);
+        entity.update_size(ino, len);
+        return Ok(len);
+    }
+}
+
+fn merge_str(offset: u64, data: &str, old_str: &str) -> Result<String> {
+    let mut new_string_len = offset + data.len() as u64;
+    if new_string_len < old_str.len() as u64 {
+        new_string_len = old_str.len() as u64;
+    }
+    let mut new_string_vec = Vec::with_capacity(new_string_len as usize);
+
+    let data_bytes = data.as_bytes();
+    let old_str_bytes = old_str.as_bytes();
+
+
+    for (i, &data) in old_str_bytes.iter().enumerate() {
+        new_string_vec.push(data);
+    }
+
+    // ----------------------
+    let data_end_offset = offset + data.len() as u64;
+    if 0 <= data_end_offset && data_end_offset <= old_str.len() as u64 {
+        for (i, &data) in data_bytes.iter().enumerate() {
+            new_string_vec[i + offset as usize] = data;
+        }
+    }
+
+    let old_str_len = old_str.len() as u64;
+    if offset < old_str_len && old_str_len < data_end_offset {
+        for (i, &data) in data_bytes.iter().enumerate() {
+            if (old_str.len() as u64) < i as u64 {
+                new_string_vec.push(data);
+                continue;
+            }
+            new_string_vec[i + offset as usize] = data;
+        }
+    }
+
+    if old_str_len <= offset {
+        for &data in data_bytes.iter() {
+            new_string_vec.push(data);
+        }
+    }
+    // ----------------------
+
+    match String::from_utf8(new_string_vec) {
+        Ok(string) => Ok(string),
+        Err(e) => Err(e.into())
     }
 }

--- a/src/usecase/repository.rs
+++ b/src/usecase/repository.rs
@@ -1,7 +1,9 @@
 use std::path;
-use crate::entity;
+use crate::entity::{self, attr};
 use anyhow::Result;
 
 pub trait File {
     fn init(&mut self, path: &path::Path) -> Result<entity::FileStruct>;
+    fn write_data(&self, ino: u64, data: &str) -> Result<()>;
+    fn update_attr(&self, attr: &attr::Attr) -> Result<()>;
 }


### PR DESCRIPTION
Close: #15

# 内容

- writeインタフェースを実装した
  ```rust
  fn write(&mut self, _req: &Request<'_>, _ino: u64, _fh: u64, _offset: i64, _data: &[u8], _flags: u32, reply: ReplyWrite) {
      ...
  }
  ```

# デモ

```
$ cat ../../mountpoint/file1 
this is content of file1hoge
$ echo wow >> ../../mountpoint/file1
$ cat ../../mountpoint/file1 
this is content of file1hoge fuck wow
```
