### PR TITLE
Bug/#30 when readdir file,doesn't update atime

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -87,68 +87,46 @@ impl FileStruct {
     }
 
     pub fn update_size(&mut self, ino: u64, size: u64) -> Result<(), Error> {
-        let attr = match self.attr.get(&ino) {
+        let attr = match self.attr.get_mut(&ino) {
             Some(attr) => attr,
             None => return Err(Error::InternalError)
         };
-
-        let new_attr = attr::new(
-            ino,
-            size,
-            attr.name().to_string(),
-            attr.kind(),
-            attr.perm(),
-            attr.uid(),
-            attr.gid(),
-            attr.atime(),
-            attr.mtime(),
-            attr.ctime()
-        );
-        self.attr.insert(ino, new_attr);
+        let size_p = attr.size_mut();
+        *size_p = size;
+        
         return Ok(());
     }
 
     pub fn update_atime(&mut self, ino: u64, st: attr::SystemTime) -> Result<(), Error> {
-        let attr = match self.attr.get(&ino) {
+        let attr = match self.attr.get_mut(&ino) {
             Some(attr) => attr,
             None => return Err(Error::InternalError)
         };
+        let atime = attr.atime_mut();
+        *atime = st;
 
-        let new_attr = attr::new(
-            ino,
-            attr.size(),
-            attr.name().to_string(),
-            attr.kind(),
-            attr.perm(),
-            attr.uid(),
-            attr.gid(),
-            st,
-            attr.mtime(),
-            attr.ctime()
-        );
-        self.attr.insert(ino, new_attr);
         return Ok(());
     }
 
     pub fn update_mtime(&mut self, ino: u64, st: attr::SystemTime) -> Result<(), Error> {
-        let attr = match self.attr.get(&ino) {
+        let attr = match self.attr.get_mut(&ino) {
             Some(attr) => attr,
             None => return Err(Error::InternalError)
         };
+        let mtime = attr.mtime_mut();
+        *mtime = st;
 
-        let new_attr = attr::new(
-            ino,
-            attr.size(),
-            attr.name().to_string(),
-            attr.kind(),
-            attr.perm(),
-            attr.uid(),
-            attr.gid(),
-            attr.atime(),
-            attr.mtime(),
-            attr.ctime(),
-        );
-        self.attr.insert(ino, new_attr);
+        return Ok(());
+    }
+
+    pub fn update_ctime(&mut self, ino: u64, st: attr::SystemTime) -> Result<(), Error> {
+        let attr = match self.attr.get_mut(&ino) {
+            Some(attr) => attr,
+            None => return Err(Error::InternalError)
+        };
+        let ctime = attr.ctime_mut();
+        *ctime = st;
+
         return Ok(());
     }
 }

--- a/src/entity/attr.rs
+++ b/src/entity/attr.rs
@@ -95,6 +95,22 @@ impl Attr {
     pub fn ctime(&self) -> SystemTime {
         self.ctime
     }
+
+    pub fn size_mut(&mut self) -> &mut u64 {
+        &mut self.size
+    }
+
+    pub fn atime_mut(&mut self) -> &mut SystemTime {
+        &mut self.atime
+    }
+
+    pub fn mtime_mut(&mut self) -> &mut SystemTime {
+        &mut self.mtime
+    }
+
+    pub fn ctime_mut(&mut self) -> &mut SystemTime {
+        &mut self.ctime
+    }
 }
 
 impl SystemTime {

--- a/src/interfaceadapter/controller.rs
+++ b/src/interfaceadapter/controller.rs
@@ -15,7 +15,7 @@ pub trait Controller {
     fn init(&mut self, config: &String) -> Result<()>;
     fn lookup(&self, parent: u64, name: &OsStr) -> Option<fuse::FileAttr>;
     fn getattr(&self, ino: u64) -> Option<fuse::FileAttr>;
-    fn readdir(&self, ino: u64) -> Option<Vec<(u64, &str, fuse::FileType)>>;
+    fn readdir(&mut self, ino: u64) -> Option<Vec<(u64, &str, fuse::FileType)>>;
     fn read(&mut self, ino: u64, offset: i64, size: u64) -> Option<&[u8]>;
     fn write(&mut self, ino: u64, offset: u64, data: &[u8]) -> Result<u32>;
 }
@@ -93,7 +93,7 @@ impl<U: usecase::Usecase> Controller for ControllerStruct<U> {
         });
     }
 
-    fn readdir(&self, ino: u64) -> Option<Vec<(u64, &str, fuse::FileType)>> {
+    fn readdir(&mut self, ino: u64) -> Option<Vec<(u64, &str, fuse::FileType)>> {
         let mut return_vec = Vec::new();
         let files_data = match self.usecase.readdir(ino) {
             Some(files_data) => files_data,


### PR DESCRIPTION
Close: #30 

# 内容

readdirシステムコールが実行された際、atime属性を更新する処理を追加

## デモ

```yaml
# Directory: 0
# TextFile: 1
- ino: 1
  name: root
  file-type: 0
  size: 2
  uid: 1000
  gid: 1000
  perm: 0o755
  atime: "1564098289.702339081"
  mtime: "1564098289.702339081"
  ctime: "1564098289.702339081"

--snip--

- ino: 1
  name: root
  file-type: 1
  size: 2
  uid: 1000
  gid: 1000
  perm: 0o755
  atime: "1642328972.661330292"
  mtime: "1564098289.702339081"
  ctime: "1564098289.702339081"
```