### PR TITLE
attr.yamlファイルに吐き出される属性を修正

### DIFF
--- a/src/externalinterface/yaml_image.rs
+++ b/src/externalinterface/yaml_image.rs
@@ -110,8 +110,8 @@ impl worker::File for YAMLImageStruct {
         };
 
         let file_type = match attr.file_type() {
-            TextFile => 1,
-            Directory => 0
+            attr::FileType::TextFile => 1,
+            attr::FileType::Directory => 0
         };
 
         content.push_str(


### PR DESCRIPTION
Close: #37 

# 内容

ディレクトリなのにも関わらず、テキストファイルとしてattr.yamlファイルに吐き出されるバグを修正

## デモ

### 修正前

```yaml
- ino: 1
  name: root
  file-type: 1
  size: 2
  uid: 1000
  gid: 1000
  perm: 0o755
  atime: "1642855722.282375832"
  mtime: "1564098289.702339081"
  ctime: "1564098289.702339081"
```

### 修正後

```yaml
- ino: 1
  name: root
  file-type: 0
  size: 2
  uid: 1000
  gid: 1000
  perm: 0o755
  atime: "1642855722.282375832"
  mtime: "1564098289.702339081"
  ctime: "1564098289.702339081"
```