### PR TITLE
mkdir rmdir renameインタフェースを実装した

### DIFF
--- a/src/entity/attr.rs
+++ b/src/entity/attr.rs
@@ -161,6 +161,10 @@ impl Attr {
     pub fn nlink_mut(&mut self) -> &mut u32 {
         &mut self.nlink
     }
+
+    pub fn set_name(&mut self, name: &str) {
+        self.name = name.to_string()
+    }
 }
 
 impl SystemTime {
@@ -306,6 +310,17 @@ impl AttrsStruct {
         let gid_p = attr.gid_mut();
         *gid_p = gid;
         return Ok(());
+    }
+
+    pub fn update_name(&mut self, ino: u64, name: &str) -> Result<(), Error> {
+        let attr = match self.attrs.get_mut(&ino) {
+            Some(attr) => attr,
+            None => return Err(Error::InternalError.into())
+        };
+
+        attr.set_name(name);
+
+        Ok(())     
     }
 
     pub fn del(&mut self, ino: u64) -> Result<Attr, Error> {

--- a/src/entity/entry.rs
+++ b/src/entity/entry.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct Entry {
-    pub ino: u64,
+    // pub ino: u64,
     pub child_ino: u64
 }
 
@@ -14,11 +14,11 @@ pub trait Entries {}
 
 impl Entry {
     pub fn new(
-        ino: u64,
+        // ino: u64,
         child_ino: u64
     ) -> Entry {
         Entry {
-            ino: ino,
+            // ino: ino,
             child_ino: child_ino
         }
     }
@@ -52,9 +52,13 @@ impl EntriesStruct {
             None => return None
         };
 
-        entry.push(Entry::new(parent_ino, child_ino));
+        entry.push(Entry::new(child_ino));
 
         Some(entry)
+    }
+
+    pub fn insert_entry(&mut self, ino: u64) {
+        self.entries.insert(ino, Vec::new());
     }
 
     // TODO: 返却値一時的になし
@@ -68,16 +72,32 @@ impl EntriesStruct {
 
         for e in entry {
             if e.child_ino() != child_ino {
-                new_entry.push(Entry::new(parent_ino, e.child_ino()));
+                new_entry.push(Entry::new(e.child_ino()));
             }
         }
 
         self.entries.insert(parent_ino, new_entry);
     }
 
+    pub fn del(&mut self, ino: u64) {
+        self.entries.remove(&ino);
+    }
     // fn insert_entry(&mut self, ino: u64) -> Option<&mut Vec<Entry>> {
     //     self.entries().insert(ino, Vec::new());
     //     self.entries().get_mut(&ino)
     // }
+
+    pub fn mov(&mut self, ino: u64, parent_ino: u64, new_parent_ino: u64) {
+        // parent_inoのエントリからinoをフィルタリングしたものを挿入
+        let mut parent_entry_vec = Vec::new();
+        for e in self.entries.get(&parent_ino).unwrap().iter() {
+            if e.child_ino() != ino {
+                parent_entry_vec.push(e.clone());
+            }
+        }
+        self.entries.insert(parent_ino, parent_entry_vec);
+
+        self.insert_child_ino(new_parent_ino, ino);
+    }
 }
 impl Entries for EntriesStruct {}

--- a/src/externalinterface/fuse.rs
+++ b/src/externalinterface/fuse.rs
@@ -177,5 +177,52 @@ impl<C: controller::Controller> Filesystem for FuseStruct<C> {
     ) {
         self.controller.forget(_ino, _nlookup);
     }
+
+    fn mkdir(
+        &mut self,
+        req: &Request<'_>,
+        parent: u64,
+        name: &OsStr,
+        mode: u32,
+        reply: ReplyEntry
+    ) {
+        // 親ディレクトリのSGIDがONの場合、子にSGIDを追加
+        // 親のスティッキービットがONの場合、子にスティッキービットを追加
+
+        match self.controller.mkdir(parent, name, mode) {
+            Ok(attr) => reply.entry(&time::Timespec{sec: 1, nsec: 0}, &attr, 0),
+            Err(_) => reply.error(libc::ENOENT)
+        };
+    }
+
+    fn rmdir(
+        &mut self,
+        _req: &Request<'_>,
+        parent: u64,
+        name: &OsStr,
+        reply: ReplyEmpty
+    ) {
+        match self.controller.rmdir(parent, name) {
+            Ok(_) => reply.ok(),
+            Err(_) => reply.error(libc::ENOENT)
+        }
+    }
+
+    fn rename(
+        &mut self,
+        _req: &Request,
+        parent: u64,
+        name: &OsStr,
+        newparent: u64,
+        newname: &OsStr,
+        reply: ReplyEmpty
+    ) {
+        match self.controller.rename(parent, name, newparent, newname) {
+            Ok(_) => reply.ok(),
+            Err(_) => reply.error(libc::ENOENT)
+        }
+    }
+
+
 }
 

--- a/src/externalinterface/yaml_image.rs
+++ b/src/externalinterface/yaml_image.rs
@@ -260,7 +260,7 @@ impl YAMLImageStruct {
                             _ => return Err(entity::Error::InvalidINO.into())
                         };
 
-                        entries.push(entry::Entry::new(ino, child_ino));
+                        entries.push(entry::Entry::new(child_ino));
                     }
                 },
                 _ => {}


### PR DESCRIPTION
Close: #48 #49 #50 

# 内容

- mkdirインタフェースの実装
- rmdirインタフェースの実装
- renameインタフェースの実装

## デモ

### mkdir

```bash
2022/03/23 05:25:34 higuruchi@myhome -> 
~/fuse-exp/data/hfs/mountpoint -> 
$ ls
directory1  file1

2022/03/23 05:25:35 higuruchi@myhome -> 
~/fuse-exp/data/hfs/mountpoint -> 
$ mkdir directory2

2022/03/23 05:25:42 higuruchi@myhome -> 
~/fuse-exp/data/hfs/mountpoint -> 
$ ls
directory1  directory2  file1
```

### rmdir

```bash
2022/03/23 05:25:42 higuruchi@myhome -> 
~/fuse-exp/data/hfs/mountpoint -> 
$ ls
directory1  directory2  file1

2022/03/23 05:25:44 higuruchi@myhome -> 
~/fuse-exp/data/hfs/mountpoint -> 
$ rmdir directory2

2022/03/23 05:26:13 higuruchi@myhome -> 
~/fuse-exp/data/hfs/mountpoint -> 
$ ls
directory1  file1
```

### rename

```bash
2022/03/23 05:27:39 higuruchi@myhome -> 
~/fuse-exp/data/hfs/mountpoint -> 
$ ls
directory1  file1

2022/03/23 05:27:39 higuruchi@myhome -> 
~/fuse-exp/data/hfs/mountpoint -> 
$ mv file1 file2

2022/03/23 05:27:47 higuruchi@myhome -> 
~/fuse-exp/data/hfs/mountpoint -> 
$ ls
directory1  file2
```

